### PR TITLE
Remove non-local lambda capturing by ref

### DIFF
--- a/headers/tools/static_initialization.hpp
+++ b/headers/tools/static_initialization.hpp
@@ -23,7 +23,7 @@ namespace tools {
 
 
 #define _STATIC_INITIALIZATION_BLOCK \
-    static tools::StaticInitializer<__COUNTER__> _UNIQUE_NAME = [&]
+    static tools::StaticInitializer<__COUNTER__> _UNIQUE_NAME = []
 
 
 #endif // _TOOLS_INITIALIZATION_HPP


### PR DESCRIPTION
I have fixed compile error:
```
In file included from main.cpp:7:
../headers/tools/static_initialization.hpp:26:66: error: non-local lambda expression cannot have a capture-default
   26 |     static tools::StaticInitializer<__COUNTER__> _UNIQUE_NAME = [&]
      |                                                                  ^
main.cpp:25:9: note: in expansion of macro ‘_STATIC_INITIALIZATION_BLOCK’
   25 |         _STATIC_INITIALIZATION_BLOCK {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:44: tests] Error 1
```
removed non-local lambda capturing by ref